### PR TITLE
Require OmniAuth and depend on omniauth-oauth2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,5 @@
 source 'http://rubygems.org'
 
-# Specify your gem's dependencies in omniauth-contrib.gemspec
-gem 'omniauth', :git => 'git://github.com/intridea/omniauth.git'
-gem 'omniauth-oauth', :git => 'git://github.com/intridea/omniauth-oauth.git'
-gem 'omniauth-oauth2', :git => 'git://github.com/intridea/omniauth-oauth2.git'
-
 gemspec
 
 group :example do

--- a/lib/omniauth-contrib.rb
+++ b/lib/omniauth-contrib.rb
@@ -1,4 +1,5 @@
 require "omniauth-contrib/version"
+require "omniauth"
 
 module OmniAuth
   module Strategies

--- a/omniauth-contrib.gemspec
+++ b/omniauth-contrib.gemspec
@@ -4,6 +4,7 @@ require File.expand_path('../lib/omniauth-contrib/version', __FILE__)
 Gem::Specification.new do |gem|
   gem.add_dependency 'omniauth', '~> 1.0.0.pr2'
   gem.add_dependency 'omniauth-oauth', '~> 1.0.0.pr2'
+  gem.add_dependency 'omniauth-oauth2', '~> 1.0.0.pr2'
   gem.add_dependency 'multi_json'
 
   gem.authors       = ["Michael Bleigh"]


### PR DESCRIPTION
In trying to install omniauth-contrib as a Git gem via Bundler, I was running into errors because OmniAuth itself is not required by omniauth-contrib, so `OmniAuth.config` errors. Also added a gem dependency for omniauth-oauth2 as it is required by two of the three strategies here. These changes allow omniauth-contrib to be installed cleanly as a Git gem.
